### PR TITLE
Use terse guard clause for git clone

### DIFF
--- a/infra/build/run.sh
+++ b/infra/build/run.sh
@@ -15,7 +15,7 @@ declare -r _PROJECT_NAME='conjob'
 declare -r _GIT_REPO='git@github.com:ScottG489/conjob.git'
 declare -r _TFSTATE_BUCKET_NAME='tfstate-conjob'
 
-git clone $_GIT_REPO
+[ -d "$_PROJECT_NAME" ] || git clone $_GIT_REPO
 cp -r $_PROJECT_NAME "$_PROJECT_NAME"_build
 cd "$_PROJECT_NAME"_build
 


### PR DESCRIPTION
## Summary
- Add terse guard clause before git clone to prevent errors if directory exists
- Makes the code consistent with other projects (e.g., regex-directed-graph-line-parser)

## Changes
```bash
# Before
git clone $_GIT_REPO

# After
[ -d "$_PROJECT_NAME" ] || git clone $_GIT_REPO
```

## Test plan
- Build process should work identically
- Guard clause prevents re-cloning if directory exists

🤖 Generated with [Claude Code](https://claude.com/claude-code)