### PR TITLE
Move terraform dep versions to top level projects

### DIFF
--- a/infra/tf/test-env/.terraform.lock.hcl
+++ b/infra/tf/test-env/.terraform.lock.hcl
@@ -36,6 +36,27 @@ provider "registry.terraform.io/hashicorp/aws" {
   ]
 }
 
+provider "registry.terraform.io/hashicorp/null" {
+  version     = "3.3.0"
+  constraints = "~> 3.3.0"
+  hashes = [
+    "h1:l+dm3lhmu4ys7GbvIldfn544olSPH0DOiYruuFSfQkY=",
+    "zh:021748b5ea3b5f6956f2e75c42c5cdc113b391fb98ac71364a4965d23b37000f",
+    "zh:3b27956f8541d46704fda234e0d535c2ae2a4b33411848b1ee262a1ec03568b0",
+    "zh:3de4ed47d6d0f4d8edba4a5092c7c9799950eda63989d8d0d2586e6afcb0aa20",
+    "zh:57ed8935c7d56dbc91cf2673534582cacfaab7a2f105f51d9f797e99df0c0c47",
+    "zh:58e176ba1d142827089e30e0711e007309a9f2726e8881986da5026e9778fdf4",
+    "zh:5949c4a3d4a93f841f155cdb7e991c087e637145c1630572e21948224f8f4923",
+    "zh:76d60f366b743003c1b085afa769b45b2198ee919927e45807d7d44fb42c067d",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:79cd1bab1261a07f84e917191d7ddc4340ac5f5524283767256f7ffd7f87caf0",
+    "zh:8ec9083038cf710b30e319eaa467c9df7fa52bbd9969b61053a35bc2cdd2e0a6",
+    "zh:a6e502cb579685ab7aeb886c2bb11ddd9cfed74b41008592d57cbc3351a9218b",
+    "zh:acb74d6b4f66ff6acfcda315df802a7432170ef3955c9b432cb4580767004006",
+    "zh:f0ce55d8d9ffdb33dab612b1246f9bab060a9d54fc32ce2b4a038646155660af",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/random" {
   version = "3.9.0"
   hashes = [
@@ -64,67 +85,5 @@ provider "registry.terraform.io/hashicorp/random" {
     "zh:8089dec888a8038b9b4fb23b3df7e1057293dbc5b60b42cc47ff690d69d4b61b",
     "zh:c51f15a031edfd6f23ce8ced3446ca7f8d8d647e2499890d7d5d10d5016d7257",
     "zh:c94784f005708890dc6895afd53636ec00ec1e430b15d41e5aebfb1d4b39bd04",
-  ]
-}
-
-provider "registry.terraform.io/hashicorp/tls" {
-  version = "4.3.0"
-  hashes = [
-    "h1:5bCU/c+2HUh7GhclzNSH6gAuoCS4inW3obEtRAwu6WQ=",
-    "h1:5xblgWaLCk0/S5sSDMEBpUO31Kv9eyvo2e0qvKDvFKg=",
-    "h1:7QWrBlzkkFAFyDl9UsfC0tdfNFquFx03miHwZcta33Q=",
-    "h1:9O6c6A3Pa8DaW0UlTqjVy9wamwN8+2xG+wfukhnVouk=",
-    "h1:Nx1AbmRplFV9vyOBwlBth+MyD5fth6Snv8lIFOsWvu0=",
-    "h1:OeJhJw1X6OeRqt8n4xMxJ8SQGTudxKT0ehqC8HxWpTE=",
-    "h1:QO1mfwRWprT41JDGRUfpIYyFs8h63yeOsB8RfKOjNYU=",
-    "h1:QjGpJjmvOB973D0BM9rPv/h9ln+wM64IGY/tfuOginw=",
-    "h1:Ubkf73KvM44o9Gh5+n9v+EskNjqGGl4wT29mQjmyUQE=",
-    "h1:eDtm+6iX4ydUbWFwQEyHzR8ukb+o5784XjotMq0C9yQ=",
-    "h1:iVr2IDV+RRoxAra3YM6w4jVsF052ougqMjbfcTtdJsw=",
-    "h1:j/BqLS2N2AScZyotd9nZpHdieJ7e5S8y+A+ZfIu8kL8=",
-    "zh:0ab58d6f8991d436c7d2dbd89ed814709b949b07ac5a54ee53b0aec1fa772a8b",
-    "zh:60b347abcb56f45d97c56f14d895069cd15a83993f199777f571b79fea3642ee",
-    "zh:6889be32640349230de3f23856e6f04e0e9ced4a84a27d3f552fa54684448218",
-    "zh:73f8e1ecf7135033165fb14b7e8bf4d656f3ce13065ec35762ea0481975328c7",
-    "zh:94ce25ee253eca0b42cae9c856b36bca8103b6453012d1b279c3623c805f2d42",
-    "zh:96bc6de9fd67bc446fd11257872e1ffb1029a996ed1d65a3f6b43f6d408ad9ab",
-    "zh:97c609a310a51bfd504d704e036d72064a84bf0bdb36cc08cd4cc66098212b41",
-    "zh:a12c16e94533c5bd123f75032576b9dc91dd5d5ccd5f7cf331d0f2e1adc55cf8",
-    "zh:c4f014f876adf7af57188795050bda5b0029d8c7d7773031102b6c36dcf1fc21",
-    "zh:d9b0a21583aaa3df3a95394fb949a3c515ff71c2ff5a1fc4a73d364aa90bfca5",
-    "zh:da510d22f0c6d71ad19a76406f106b782448f512375787ecfabb338ed1e311a7",
-    "zh:f0e9447a9ce3a24cdaa113089e65663c836d8b9bfdb915a1c0284e0112cab5c0",
-    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
-  ]
-}
-
-provider "registry.terraform.io/vancluever/acme" {
-  version     = "2.48.1"
-  constraints = "~> 2.0"
-  hashes = [
-    "h1:DBgKwg7wehf5PMSG2RH9gDRhy44wWkt3UeFOyh3jz+U=",
-    "h1:Itc92YFCkhjq2R+okeJhlgu2B9mH8ILP5JhxSwwuSgE=",
-    "h1:NZ+SMaPJmPEOA7D3nFWFvZ6IrxQxzJ8zgJEkAidrWIE=",
-    "h1:OBuZ0iAFBDKwOPFMl8kl+/qMimoAxolzoCpUnC+GYM0=",
-    "h1:PxUTXPpXx/9d9uMIPhvDLdHWBzqFx73LvRy0+dclrk4=",
-    "h1:S2oVD3dodJRwrEkFLS7t6gx0TKBRyQM0+2WD8tvevHA=",
-    "h1:ZtLyx1CR6hgXM5ijkuqcG4WaB8A+53TbIjlnNN55F/s=",
-    "h1:bVuyZGFtmeG5kbqtLWpIdrGakMhEKPKdd49c3PWNsRk=",
-    "h1:dEo869ZOOYeuWJu6LN5FSv29Wha+IibGSADboNinKnI=",
-    "h1:sQANy7E4wnCal++HMKuuDnZmRaaUXcT/x0A5KtlZsxs=",
-    "h1:u5AOnQ8WH1VZ/7YvCHrV9ndMHOoQDJFv1sEwS7oDx2k=",
-    "h1:uEilEi/xUf75jZ6xDcEK5CeQJnId8HqSlDNPvQmxiwM=",
-    "zh:489a949a2351bd7b83475f061c872c4a778f51f22e92996eaf20264bb0a6bc6a",
-    "zh:5656d34b5213d1afffd03b1ea4e324738cff1fd92c23fee17557b3f736d076fd",
-    "zh:63a89545832bbb7688c78f6816645f1f7a46de87dabfce317408d3fea87d6d2e",
-    "zh:70671e35bbae2f8680090cc5ec337b94f8d7ae00b40235150e10f638d34a4fd3",
-    "zh:88b169bf2a8919a69b32ed5add4c314d7acfdf071cf3b59064776ba973b585d4",
-    "zh:89e50591e386738dd86ce82be2becf1a88d002881f92011bc03f6b799e231d82",
-    "zh:977a7b3426a876fe463d7452c3c918ff77e06a510b57d542b41b2801b314dcb9",
-    "zh:cc1c56840415862a2a225d3adba407b4e2e96d5551e4fb1fcc9db7cb32284ca7",
-    "zh:d617b84a49cfb03418a806f27790bc05666e67d39d7d4b92f8c8de8c6acfb95c",
-    "zh:ea5e3b4f5e60d1ae4101de77fcaf202ec6e739f5475c90d9358639a4d5742b39",
-    "zh:f055b4de8fec8c2ab8ad12c8ca2d5c5034173f1dc3d603090acc3e2040d73917",
-    "zh:f7c3d56be13d9b41b1fc6f44ce44aeda1c9c0d9d283afa7682abc6680b302a4a",
   ]
 }

--- a/infra/tf/test-env/versions.tf
+++ b/infra/tf/test-env/versions.tf
@@ -4,6 +4,10 @@ terraform {
       source  = "hashicorp/aws"
       version = "~> 6.0"
     }
+    null = {
+      source  = "hashicorp/null"
+      version = "~> 3.3.0"
+    }
     random = {
       source  = "hashicorp/random"
       version = "~> 3.0"

--- a/infra/tf/versions.tf
+++ b/infra/tf/versions.tf
@@ -13,6 +13,14 @@ terraform {
       source  = "vancluever/acme"
       version = "~> 2.0"
     }
+    null = {
+      source  = "hashicorp/null"
+      version = "~> 3.3.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.9.0"
+    }
   }
   required_version = ">= 0.13"
 }


### PR DESCRIPTION
This seems like best practice and was also causing issues with renovate
otherwise.

Versions are now specified in the prod and test modules instead of the
shared module.
